### PR TITLE
docs: add LICENSE and README, create firewall updater script

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,11 @@
+# The Unlicense
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,73 @@
 # hcloud-firewall-updater
+
+A Bash script to automatically update Hetzner Cloud firewall rules with your current public IP address.
+
+## Description
+
+This script automates the process of updating a Hetzner Cloud firewall rule to allow SSH access from your current public IP address. It's particularly useful for users with dynamic IP addresses who need to maintain secure access to their Hetzner Cloud resources.
+
+## Features
+
+- Automatically detects your current public IP address
+- Updates the specified Hetzner Cloud firewall's SSH rule
+- Removes old IP addresses from the rule
+- Can be run manually or automatically on shell startup
+
+## Prerequisites
+
+- Hetzner Cloud account
+- `hcloud` CLI tool installed and configured with your Hetzner Cloud API token
+- `jq` command-line JSON processor
+- `curl` command-line tool for transferring data
+
+## Installation
+
+1. Clone this repository or download the script:
+git clone https://github.com/hra42/hcloud-firewall-updater.git
+
+or
+wget https://raw.githubusercontent.com/hra42/hcloud-firewall-updater/main/update_hcloud_firewall.sh
+
+
+2. Make the script executable:
+chmod +x update_hcloud_firewall.sh
+
+
+## Usage
+
+Run the script manually by providing the name of your Hetzner Cloud firewall:
+
+./update_hcloud_firewall.sh your-firewall-name
+
+
+To run the script automatically when opening a new shell, add the following line to your `.bashrc`, `.zshrc`, or `.profile`:
+
+/path/to/update_hcloud_firewall.sh your-firewall-name > /dev/null 2>&1
+
+
+Replace `/path/to/update_hcloud_firewall.sh` with the actual path to the script, and `your-firewall-name` with the name of your Hetzner Cloud firewall.
+
+## How It Works
+
+1. The script retrieves your current public IP address.
+2. It then finds the specified firewall in your Hetzner Cloud project.
+3. If an SSH rule exists, it updates the rule to only allow access from your current IP.
+4. If no SSH rule exists, it creates a new rule for SSH access from your current IP.
+
+## Troubleshooting
+
+- Ensure that the `hcloud` CLI is properly configured with your Hetzner Cloud API token.
+- Check that you have the necessary permissions to modify firewalls in your Hetzner Cloud project.
+- Verify that `jq` and `curl` are installed on your system.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+This project is licensed under the Unlicense - see the [LICENSE](LICENSE.md) file for details.
+
+## Disclaimer
+
+This script is provided as-is, without any warranties. Always ensure you understand the script's actions before using it in your environment.

--- a/firewallupdater.sh
+++ b/firewallupdater.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Function to get the current public IP address
+get_public_ip() {
+    curl -s https://api.ipify.org
+}
+
+# Function to get the firewall ID
+get_firewall_id() {
+    local firewall_name="$1"
+    hcloud firewall list -o json | jq -r ".[] | select(.name == \"$firewall_name\") | .id"
+}
+
+# Function to update the firewall rule
+update_firewall() {
+    local firewall_id="$1"
+    local current_ip="$2"
+
+    # Get the existing rules
+    local rules=$(hcloud firewall describe "$firewall_id" -o json | jq -r '.rules')
+
+    # Find the SSH rule
+    local ssh_rule=$(echo "$rules" | jq -r '.[] | select(.description == "SSH")')
+
+    if [ -z "$ssh_rule" ]; then
+        echo "No rule with description 'SSH' found. Adding a new rule."
+        hcloud firewall add-rule "$firewall_id" \
+            --description "SSH" \
+            --direction in \
+            --protocol tcp \
+            --port 22 \
+            --source-ips "$current_ip/32"
+    else
+        # Extract the existing rule details
+        local direction=$(echo "$ssh_rule" | jq -r '.direction')
+        local port=$(echo "$ssh_rule" | jq -r '.port')
+        local protocol=$(echo "$ssh_rule" | jq -r '.protocol')
+        local old_ips=$(echo "$ssh_rule" | jq -r '.source_ips | join(",")')
+
+        # Check if the current IP is already the only IP in the rule
+        if [ "$old_ips" = "$current_ip/32" ]; then
+            echo "Current IP is already the only IP in the firewall rule. No update needed."
+            return
+        fi
+
+        # Update the rule with only the new IP
+        hcloud firewall set-rules "$firewall_id" \
+            --rules-file <(echo "[
+                {
+                    \"description\": \"SSH\",
+                    \"direction\": \"$direction\",
+                    \"protocol\": \"$protocol\",
+                    \"port\": \"$port\",
+                    \"source_ips\": [
+                        \"$current_ip/32\"
+                    ]
+                }
+            ]")
+
+        echo "Firewall rule updated. Old IP(s) removed, new IP added."
+    fi
+}
+
+# Main script
+
+# Check if a firewall name is provided
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <firewall_name>"
+    exit 1
+fi
+
+FIREWALL_NAME="$1"
+
+# Get the firewall ID
+FIREWALL_ID=$(get_firewall_id "$FIREWALL_NAME")
+
+if [ -z "$FIREWALL_ID" ]; then
+    echo "No firewall found with the name: $FIREWALL_NAME"
+    exit 1
+fi
+
+echo "Found firewall with ID: $FIREWALL_ID"
+
+# Get the current public IP
+CURRENT_IP=$(get_public_ip)
+
+if [ -z "$CURRENT_IP" ]; then
+    echo "Failed to get current IP address"
+    exit 1
+fi
+
+echo "Current IP: $CURRENT_IP"
+
+# Update the firewall
+update_firewall "$FIREWALL_ID" "$CURRENT_IP"
+
+echo "Firewall update process completed"


### PR DESCRIPTION
This commit adds a LICENSE file using The Unlicense, creates a
detailed README explaining the project's purpose and usage, and
implements the main firewall updater script.

The README provides installation instructions, usage guidelines,
and explains how the script works. The firewall updater script
automates updating Hetzner Cloud firewall rules with the user's
current public IP address for SSH access.